### PR TITLE
Refactor hooks into modular structure

### DIFF
--- a/scripts/conditions.js
+++ b/scripts/conditions.js
@@ -1,0 +1,169 @@
+import { moduleId, actorConditionMap, targetConditionMap } from "./constants.js";
+import { distanceBetween, getSetting } from "./utils.js";
+
+function usePf2ePerceptionInstead() {
+  return (
+    game.modules.get("pf2e-perception")?.active &&
+    ["roll", "cancel"].includes(game.settings.get("pf2e-perception", "flat-check"))
+  );
+}
+
+function getAttackerInfo(token, target) {
+  const attacker = token?.actor;
+  const info = {
+    blinded: !!attacker?.items?.find((i) => i.slug === "blinded"),
+    dazzled: !!attacker?.items?.find((i) => i.slug === "dazzled"),
+    blindFight: !!attacker?.items?.find((i) => i.slug === "blind-fight"),
+    liminalFetchling: !!attacker?.items?.find(
+      (i) =>
+        i.slug === "liminal-fetchling" ||
+        i.system?.slug === "liminal-fetchling" ||
+        i.slug === "laminal-fetchling" ||
+        i.system?.slug === "laminal-fetchling"
+    ),
+    hasMothSupportEffect: !!attacker?.items.some(
+      (i) => i.type === "effect" && i.name === "Effect: Moth Support Benefit"
+    ),
+    keenEyes: !!attacker?.items?.find((i) => i.slug === "keen-eyes"),
+    grabbed: !!attacker?.items?.find((i) => i.slug === "grabbed"),
+    adjacent: target ? distanceBetween(token, target) <= 5 : false,
+    equalOrHigherLevel: target
+      ? (attacker?.level || -Infinity) >= (target?.actor?.level || Infinity)
+      : false,
+  };
+  return info;
+}
+
+function gatherConditions(token, target, isSpell, conditionMap, checkingAttacker, info) {
+  const currentActor = checkingAttacker ? token.actor : target.actor;
+
+  const conditions = currentActor.itemTypes.condition
+    .filter((c) => {
+      if (checkingAttacker && isSpell && c.slug === "stupefied") return true;
+      if (["hidden", "concealed", "undetected", "dazzled"].includes(c.slug) && usePf2ePerceptionInstead())
+        return false;
+      return Object.keys(conditionMap).includes(c.slug);
+    })
+    .map((c) => c.slug)
+    .sort();
+
+  if (!checkingAttacker && info.blinded && !conditions.includes("hidden") && !usePf2ePerceptionInstead())
+    conditions.push("hidden");
+  if (!checkingAttacker && info.dazzled && !conditions.includes("concealed") && !usePf2ePerceptionInstead())
+    conditions.push("concealed");
+
+  if (!checkingAttacker && game.modules.get("pf2e-darkness-effects")?.active) {
+    const attackerLowLightVision = token.actor.system.traits.senses.some((s) => s.type === "lowLightVision");
+    const targetInDimLight = currentActor.getFlag("pf2e-darkness-effects", "darknessLevel") === 1;
+    if (targetInDimLight && !attackerLowLightVision && !conditions.includes("concealed"))
+      conditions.push("concealed");
+
+    const attackerDarkvision = token.actor.system.traits.senses.some((s) => s.type === "darkvision");
+    const targetInDarkness = currentActor.getFlag("pf2e-darkness-effects", "darknessLevel") === 0;
+    if (targetInDarkness && !attackerDarkvision && !conditions.includes("hidden"))
+      conditions.push("hidden");
+  }
+
+  let stupefyLevel;
+  if (conditions.includes("stupefied")) {
+    stupefyLevel = currentActor.itemTypes.condition.find((c) => c.slug === "stupefied")?.value;
+    if (stupefyLevel) conditionMap["stupefied"] = stupefyLevel + 5;
+  }
+
+  return { conditions, stupefyLevel };
+}
+
+function determineCondition(conditionList, stupefyLevel, conditionMap, info, checkingAttacker, traits) {
+  if (!conditionList || conditionList.length === 0) return {};
+
+  let baseCondition = conditionList.reduce((acc, curr) => {
+    const accDC = conditionMap[acc] ?? -Infinity;
+    const currDC = conditionMap[curr] ?? -Infinity;
+    return accDC >= currDC ? acc : curr;
+  });
+
+  let logicalCondition = baseCondition;
+  if (logicalCondition === "invisible" || baseCondition === "undetected") {
+    logicalCondition = "hidden";
+  }
+  let DC = conditionMap[logicalCondition];
+
+  if (baseCondition === "stupefied" && typeof stupefyLevel === "number") {
+    DC = stupefyLevel + 5;
+  }
+
+  if (checkingAttacker && info.blindFight && baseCondition === "dazzled") return {};
+
+  if (!checkingAttacker) {
+    if (info.liminalFetchling || info.keenEyes || info.hasMothSupportEffect) {
+      if (logicalCondition === "concealed") DC = 3;
+      if (logicalCondition === "hidden") DC = 9;
+    }
+
+    if (info.blindFight) {
+      if (baseCondition === "concealed") return {};
+      if (baseCondition === "hidden") DC = 5;
+      if ((baseCondition === "invisible" || baseCondition === "undetected") && info.adjacent && info.equalOrHigherLevel) {
+        baseCondition = "hidden";
+        DC = 5;
+      }
+    }
+  }
+
+  if (checkingAttacker && info.grabbed && traits?.includes("manipulate")) {
+    if (5 > DC || DC === undefined) {
+      baseCondition = "grabbed";
+      DC = 5;
+    }
+  }
+
+  if (DC === -Infinity) return {};
+
+  return { condition: baseCondition, DC };
+}
+
+function shouldIgnoreCondition(conditionName, areaAttack, ignoreConcealed, ignoreInvisibility, ignoreGrabbed) {
+  return (
+    ((conditionName === "Concealed" || conditionName === "Dazzled") &&
+      (ignoreConcealed || areaAttack)) ||
+    ((conditionName === "Hidden" || conditionName === "Invisible") &&
+      (ignoreInvisibility || areaAttack)) ||
+    (conditionName === "Grabbed" && ignoreGrabbed)
+  );
+}
+
+export function getCondition(token, target, isSpell, traits, areaAttack) {
+  const ignoreConcealed = getSetting("ignoreConcealed");
+  const ignoreGrabbed = getSetting("ignoreGrabbed");
+  const ignoreInvisibility = getSetting("ignoreInvisibility");
+
+  const checkingAttacker = target === null;
+  const conditionMap = checkingAttacker ? { ...actorConditionMap } : targetConditionMap;
+  const info = getAttackerInfo(token, target);
+
+  const { conditions, stupefyLevel } = gatherConditions(
+    token,
+    target,
+    isSpell,
+    conditionMap,
+    checkingAttacker,
+    info
+  );
+
+  const { condition, DC } = determineCondition(
+    conditions,
+    stupefyLevel,
+    conditionMap,
+    info,
+    checkingAttacker,
+    traits
+  );
+
+  const conditionName =
+    condition && condition.length > 0 ? condition.charAt(0).toUpperCase() + condition.slice(1) : condition;
+
+  if (shouldIgnoreCondition(conditionName, areaAttack, ignoreConcealed, ignoreInvisibility, ignoreGrabbed)) {
+    return {};
+  }
+  return { conditionName, DC };
+}

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,0 +1,13 @@
+export const moduleId = "pf2-flat-check";
+
+export const actorConditionMap = {
+  blinded: -Infinity, //Just so it gets picked up. DC partially depends on target.
+  dazzled: 5,
+};
+
+export const targetConditionMap = {
+  concealed: 5,
+  hidden: 11,
+  invisible: 11, //Treated as Undetected
+  undetected: 11,
+};

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,18 +1,8 @@
-const moduleId = "pf2-flat-check";
+import { moduleId } from "./constants.js";
+import { getCondition } from "./conditions.js";
+import { getSetting } from "./utils.js";
 
-const actorConditionMap = {
-  blinded: -Infinity, //Just so it gets picked up. DC partially depends on target.
-  dazzled: 5,
-};
-
-const targetConditionMap = {
-  concealed: 5,
-  hidden: 11,
-  invisible: 11, //Treated as Undetected
-  undetected: 11,
-};
-
-Hooks.once("init", () => {
+function registerSettings() {
   game.settings.register(moduleId, "hideRollValue", {
     name: `pf2-flat-check.settings.hideRollValue.name`,
     hint: `pf2-flat-check.settings.hideRollValue.hint`,
@@ -61,31 +51,14 @@ Hooks.once("init", () => {
     type: Boolean,
     default: true,
   });
-});
+}
 
-Hooks.on("createChatMessage", async (message, data, userID) => {
-  if (game.user.id !== game.users.find((u) => u.isGM && u.active).id) return;
+Hooks.once("init", registerSettings);
 
-  const actor = message?.actor ?? game.actors.get(message?.speaker?.actor);
-  const token = message?.token ?? game.canvas.tokens.get(message?.speaker?.token);
+function getItemFromMessage(message, actor) {
   let { item } = message;
   const originUUID = message.flags.pf2e?.origin?.uuid;
-  //console.log(message);
-  //Domäne prüfen, falls Schaden, dann Abbruch
-  const domains = message.flags?.pf2e?.context?.domains || [];
-  if (domains.includes("damage") || domains.includes("attack-damage") || domains.includes("damage-received")) {
-    return;
-}
-//Falls der Wurf persistenten Schaden enthält dann Abbruch
-if (message.rolls?.some(roll => roll.options?.evaluatePersistent) || (message.isDamageTakenRoll)) {
-  return;
-}
-  if (
-    !item &&
-    !message.isDamageRoll &&
-    originUUID?.match(/Item.(\w+)/) &&
-    RegExp.$1 === "xxPF2ExUNARMEDxx"
-  ) {
+  if (!item && !message.isDamageRoll && originUUID?.match(/Item.(\w+)/) && RegExp.$1 === "xxPF2ExUNARMEDxx") {
     const actionIds = originUUID.match(/Item.(\w+)/);
     if (actionIds && actionIds[1]) {
       item =
@@ -94,29 +67,43 @@ if (message.rolls?.some(roll => roll.options?.evaluatePersistent) || (message.is
           .filter((a) => a.item.id === actionIds[1]) || null;
     }
   }
-  if (!actor || !item) return;
-  if (
-    ["ancestry", "effect", "feat", "melee", "weapon"].includes(item.type) &&
-    (!message.isRoll || message.isDamageRoll)
-  )
-    return;
-  if (item.type === "spell" && message.isRoll) return;
+  return item;
+}
 
-  const ignorePassiveActions = game.settings.get(moduleId,"ignorePassiveActions");
-  const ignoreReactionActions = game.settings.get(moduleId,"ignoreReactionActions");
+function shouldHandleMessage(message, item) {
+  const domains = message.flags?.pf2e?.context?.domains || [];
+  if (domains.includes("damage") || domains.includes("attack-damage") || domains.includes("damage-received")) {
+    return false;
+  }
+  if (message.rolls?.some((r) => r.options?.evaluatePersistent) || message.isDamageTakenRoll) {
+    return false;
+  }
+  if (["ancestry", "effect", "feat", "melee", "weapon"].includes(item.type) && (!message.isRoll || message.isDamageRoll)) {
+    return false;
+  }
+  if (item.type === "spell" && message.isRoll) return false;
+
   const isPassiveAbility = message.content.includes('icons/actions/Passive.webp');
   const isReaction = message.content.includes('icons/actions/Reaction.webp');
-
-  if ((isPassiveAbility && ignorePassiveActions) || (isReaction && ignoreReactionActions)) {
-    return;
-}
-  let areaAttack = false;
-  const rollOptions = message.flags?.pf2e?.origin?.rollOptions || [];
-  if (rollOptions.includes("area-effect") || rollOptions.includes("area-damage") || 
-      rollOptions.includes("aura") || message.content.includes('data-pf2-effect-area') ||
-      message.flags?.pf2e?.context?.type === "self-effect") {
-    areaAttack = true;
+  if ((isPassiveAbility && getSetting("ignorePassiveActions")) || (isReaction && getSetting("ignoreReactionActions"))) {
+    return false;
   }
+  return true;
+}
+
+function detectAreaAttack(message) {
+  const rollOptions = message.flags?.pf2e?.origin?.rollOptions || [];
+  return (
+    rollOptions.includes("area-effect") ||
+    rollOptions.includes("area-damage") ||
+    rollOptions.includes("aura") ||
+    message.content.includes('data-pf2-effect-area') ||
+    message.flags?.pf2e?.context?.type === "self-effect"
+  );
+}
+
+function prepareFlatCheckData(message, token, actor, item, userID) {
+  const areaAttack = detectAreaAttack(message);
   const templateData = {};
   const { conditionName, DC } = getCondition(
     token,
@@ -136,57 +123,42 @@ if (message.rolls?.some(roll => roll.options?.evaluatePersistent) || (message.is
   let anyTargetUndetected = false;
   let targetCount = 1;
   for (const target of targets) {
-    const { conditionName, DC } = getCondition(
+    const { conditionName: tCondition, DC: tDC } = getCondition(
       token,
       target,
       item.type === "spell",
       null,
       areaAttack
     );
-    if (!conditionName) continue;
+    if (!tCondition) continue;
 
-    const visibility = game.settings.get(
-      "pf2e",
-      "metagame_tokenSetsNameVisibility"
-    );
+    const visibility = game.settings.get("pf2e", "metagame_tokenSetsNameVisibility");
     templateData.targets.push({
-      name:
-        visibility && [0, 20, 40].includes(target.document.displayName)
-          ? "Target " + targetCount++
-          : target.name,
-      condition: conditionName,
+      name: visibility && [0, 20, 40].includes(target.document.displayName) ? "Target " + targetCount++ : target.name,
+      condition: tCondition,
     });
 
-    if (DC > templateData.flatCheckDC) templateData.flatCheckDC = DC;
-    if (
-      target.actor.itemTypes?.condition
-        .map((n) => n.name)
-        ?.includes("Undetected")
-    )
-      anyTargetUndetected = true;
+    if (tDC > templateData.flatCheckDC) templateData.flatCheckDC = tDC;
+    if (target.actor.itemTypes?.condition.map((n) => n.name)?.includes("Undetected")) anyTargetUndetected = true;
   }
 
-  if (!templateData.actor.condition && !templateData.targets.length) return;
+  return { templateData, anyTargetUndetected };
+}
 
+async function showFlatCheckResult(templateData, userID, anyTargetUndetected, token, actor) {
   const flatCheckRoll = new Roll("1d20");
   await flatCheckRoll.evaluate();
-  if (game.dice3d)
-    await game.dice3d.showForRoll(flatCheckRoll, game.users.get(userID), true);
+  if (game.dice3d) await game.dice3d.showForRoll(flatCheckRoll, game.users.get(userID), true);
 
-  templateData.flatCheckRollResult = !game.settings.get(
-    moduleId,
-    "hideRollValue"
-  )
+  templateData.flatCheckRollResult = !getSetting("hideRollValue")
     ? flatCheckRoll.result
     : flatCheckRoll.result < templateData.flatCheckDC
-      ? game.i18n.localize("pf2-flat-check.results.failure")
-      : game.i18n.localize("pf2-flat-check.results.success");
+    ? game.i18n.localize("pf2-flat-check.results.failure")
+    : game.i18n.localize("pf2-flat-check.results.success");
 
   templateData.flatCheckRollResultClass =
-    flatCheckRoll.result < templateData.flatCheckDC
-      ? "flat-check-failure"
-      : "flat-check-success";
-      
+    flatCheckRoll.result < templateData.flatCheckDC ? "flat-check-failure" : "flat-check-success";
+
   const content = await foundry.applications.handlebars.renderTemplate(
     `modules/${moduleId}/templates/flat-check.hbs`,
     templateData
@@ -198,196 +170,23 @@ if (message.rolls?.some(roll => roll.options?.evaluatePersistent) || (message.is
       actor,
       user: game.users.get(userID),
     }),
-    whisper: anyTargetUndetected
-      ? ChatMessage.getWhisperRecipients("GM").map((u) => u.id)
-      : null,
+    whisper: anyTargetUndetected ? ChatMessage.getWhisperRecipients("GM").map((u) => u.id) : null,
     blind: anyTargetUndetected,
     flags: { "pf2-flat-check": true },
   });
+}
+
+Hooks.on("createChatMessage", async (message, data, userID) => {
+  if (game.user.id !== game.users.find((u) => u.isGM && u.active).id) return;
+
+  const actor = message?.actor ?? game.actors.get(message?.speaker?.actor);
+  const token = message?.token ?? game.canvas.tokens.get(message?.speaker?.token);
+  const item = getItemFromMessage(message, actor);
+  if (!actor || !item) return;
+  if (!shouldHandleMessage(message, item)) return;
+
+  const { templateData, anyTargetUndetected } = prepareFlatCheckData(message, token, actor, item, userID);
+  if (!templateData.actor.condition && !templateData.targets.length) return;
+
+  await showFlatCheckResult(templateData, userID, anyTargetUndetected, token, actor);
 });
-
-function distanceBetween(token0, token1) {
-  const ray = new foundry.canvas.geometry.Ray(
-    new PIXI.Point(token0?.x || 0, token0?.y || 0),
-    new PIXI.Point(token1?.x || 0, token1?.y || 0)
-  );
-  const x = Math.ceil(Math.abs(ray.dx / canvas.dimensions.size));
-  const y = Math.ceil(Math.abs(ray.dy / canvas.dimensions.size));
-  return (
-    Math.floor(Math.min(x, y) + Math.abs(y - x)) * canvas.dimensions.distance
-  );
-}
-
-function getAttackerInfo(token, target) {
-  const attacker = token?.actor;
-  const info = {
-    blinded: !!attacker?.items?.find((i) => i.slug === "blinded"),
-    dazzled: !!attacker?.items?.find((i) => i.slug === "dazzled"),
-    blindFight: !!attacker?.items?.find((i) => i.slug === "blind-fight"),
-    liminalFetchling: !!attacker?.items?.find(
-      (i) =>
-        i.slug === "liminal-fetchling" ||
-        i.system?.slug === "liminal-fetchling" ||
-        i.slug === "laminal-fetchling" ||
-        i.system?.slug === "laminal-fetchling"
-    ),
-    hasMothSupportEffect: !!attacker?.items.some(i =>
-      i.type === "effect" && i.name === "Effect: Moth Support Benefit"
-    ),
-    keenEyes: !!attacker?.items?.find((i) => i.slug === "keen-eyes"),
-    grabbed: !!attacker?.items?.find((i) => i.slug === "grabbed"),
-    adjacent: target ? distanceBetween(token, target) <= 5 : false,
-    equalOrHigherLevel: target
-      ? (attacker?.level || -Infinity) >= (target?.actor?.level || Infinity)
-      : false,
-  };
-  return info;
-}
-
-function gatherConditions(token, target, isSpell, conditionMap, checkingAttacker, info) {
-  const currentActor = checkingAttacker ? token.actor : target.actor;
-
-  const conditions = currentActor.itemTypes.condition
-    .filter((c) => {
-      if (checkingAttacker && isSpell && c.slug === "stupefied") return true;
-      if (["hidden", "concealed", "undetected", "dazzled"].includes(c.slug) && usePf2ePerceptionInstead())
-        return false;
-      return Object.keys(conditionMap).includes(c.slug);
-    })
-    .map((c) => c.slug)
-    .sort();
-
-  if (!checkingAttacker && info.blinded && !conditions.includes("hidden") && !usePf2ePerceptionInstead())
-    conditions.push("hidden");
-  if (!checkingAttacker && info.dazzled && !conditions.includes("concealed") && !usePf2ePerceptionInstead())
-    conditions.push("concealed");
-
-  if (!checkingAttacker && game.modules.get("pf2e-darkness-effects")?.active) {
-    const attackerLowLightVision = token.actor.system.traits.senses.some((s) => s.type === "lowLightVision");
-    const targetInDimLight = currentActor.getFlag("pf2e-darkness-effects", "darknessLevel") === 1;
-    if (targetInDimLight && !attackerLowLightVision && !conditions.includes("concealed"))
-      conditions.push("concealed");
-
-    const attackerDarkvision = token.actor.system.traits.senses.some((s) => s.type === "darkvision");
-    const targetInDarkness = currentActor.getFlag("pf2e-darkness-effects", "darknessLevel") === 0;
-    if (targetInDarkness && !attackerDarkvision && !conditions.includes("hidden"))
-      conditions.push("hidden");
-  }
-
-  let stupefyLevel;
-  if (conditions.includes("stupefied")) {
-    stupefyLevel = currentActor.itemTypes.condition.find((c) => c.slug === "stupefied")?.value;
-    if (stupefyLevel) conditionMap["stupefied"] = stupefyLevel + 5;
-  }
-
-  return { conditions, stupefyLevel };
-}
-
-function determineCondition(conditionList, stupefyLevel, conditionMap, info, checkingAttacker, traits) {
-  if (!conditionList || conditionList.length === 0) return {};
-
-  // 1. Ursprünglich härteste Bedingung ermitteln (höchster conditionMap-DC)
-  let baseCondition = conditionList.reduce((acc, curr) => {
-    const accDC = conditionMap[acc] ?? -Infinity;
-    const currDC = conditionMap[curr] ?? -Infinity;
-    return accDC >= currDC ? acc : curr;
-  });
-
-  console.log(baseCondition);
-
-  let logicalCondition = baseCondition;
-  if (logicalCondition === "invisible" || baseCondition === "undetected") {
-    logicalCondition = "hidden";
-  }
-  // 2. DC initial setzen
-  let DC = conditionMap[logicalCondition];
-
-  // 3. Spezialfälle behandeln (z. B. stupefied-Level)
-  if (baseCondition === "stupefied" && typeof stupefyLevel === "number") {
-    DC = stupefyLevel + 5;
-  }
-
-  // 4. Reduktionen anwenden
-  if (checkingAttacker && info.blindFight && baseCondition === "dazzled") return {};
-
-  if (!checkingAttacker) {
-    if (info.liminalFetchling || info.keenEyes || info.hasMothSupportEffect) {
-      if (logicalCondition === "concealed") DC = 3;
-      if (logicalCondition === "hidden") DC = 9;
-    }
-
-    if (info.blindFight) {
-      if (baseCondition === "concealed") return {};
-      if (baseCondition === "hidden") DC = 5;
-      if ((baseCondition === "invisible" || baseCondition === "undetected") && info.adjacent && info.equalOrHigherLevel) {
-        baseCondition = "hidden";
-        DC = 5;
-      }
-    }
-  }
-
-  // 5. Sonderfall "grabbed" bei Angreifer und Manipulate
-  if (checkingAttacker && info.grabbed && traits?.includes("manipulate")) {
-    if (5 > DC || DC === undefined) {
-      baseCondition = "grabbed";
-      DC = 5;
-    }
-  }
-
-  if (DC === -Infinity) return {};
-
-  return { condition: baseCondition, DC };
-}
-
-
-function shouldIgnoreCondition(conditionName, areaAttack, ignoreConcealed, ignoreInvisibility, ignoreGrabbed) {
-  return (
-    ((conditionName === "Concealed" || conditionName === "Dazzled") &&
-      (ignoreConcealed || areaAttack)) ||
-    ((conditionName === "Hidden" || conditionName === "Invisible") &&
-      (ignoreInvisibility || areaAttack)) ||
-    (conditionName === "Grabbed" && ignoreGrabbed)
-  );
-}
-
-function getCondition(token, target, isSpell, traits, areaAttack) {
-  const ignoreConcealed = game.settings.get(moduleId, "ignoreConcealed");
-  const ignoreGrabbed = game.settings.get(moduleId, "ignoreGrabbed");
-  const ignoreInvisibility = game.settings.get(moduleId, "ignoreInvisibility");
-
-  const checkingAttacker = target === null;
-  const conditionMap = checkingAttacker ? { ...actorConditionMap } : targetConditionMap;
-  const info = getAttackerInfo(token, target);
-
-  const { conditions, stupefyLevel } = gatherConditions(
-    token,
-    target,
-    isSpell,
-    conditionMap,
-    checkingAttacker,
-    info
-  );
-
-  const { condition, DC } = determineCondition(
-    conditions,
-    stupefyLevel,
-    conditionMap,
-    info,
-    checkingAttacker,
-    traits
-  );
-
-  const conditionName =
-    condition && condition.length > 0
-      ? condition.charAt(0).toUpperCase() + condition.slice(1)
-      : condition;
-
-  if (shouldIgnoreCondition(conditionName, areaAttack, ignoreConcealed, ignoreInvisibility, ignoreGrabbed)) {
-    return {};
-  }
-  return { conditionName, DC };
-}
-
-function usePf2ePerceptionInstead() {
-  return game.modules.get("pf2e-perception")?.active && ['roll', 'cancel'].includes(game.settings.get("pf2e-perception", "flat-check"))
-}

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,17 @@
+import { moduleId } from "./constants.js";
+
+export function getSetting(key) {
+  return game.settings.get(moduleId, key);
+}
+
+export function distanceBetween(token0, token1) {
+  const ray = new foundry.canvas.geometry.Ray(
+    new PIXI.Point(token0?.x || 0, token0?.y || 0),
+    new PIXI.Point(token1?.x || 0, token1?.y || 0)
+  );
+  const x = Math.ceil(Math.abs(ray.dx / canvas.dimensions.size));
+  const y = Math.ceil(Math.abs(ray.dy / canvas.dimensions.size));
+  return (
+    Math.floor(Math.min(x, y) + Math.abs(y - x)) * canvas.dimensions.distance
+  );
+}


### PR DESCRIPTION
## Summary
- extract constants and utilities
- move condition logic to new module
- restructure `createChatMessage` handler for clarity
- add helper for settings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685557b3f9c48327bd876359a0f75d13